### PR TITLE
Sonar disable/enable command added

### DIFF
--- a/examples/sonar_disable.py
+++ b/examples/sonar_disable.py
@@ -1,0 +1,85 @@
+"""
+ Copyright (c) 2020 Alan Yorinks All rights reserved.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ Version 3 as published by the Free Software Foundation; either
+ or (at your option) any later version.
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU AFFERO GENERAL PUBLIC LICENSE
+ along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+
+import asyncio
+import sys
+import time
+from telemetrix_aio import telemetrix_aio
+
+"""
+This program continuously monitors an HC-SR04 Ultrasonic Sensor
+It reports changes to the distance sensed.
+"""
+TRIGGER_PIN = 9
+ECHO_PIN = 10
+
+# indices into callback data
+REPORT_TYPE = 0
+TRIG_PIN = 1
+DISTANCE = 2
+TIME = 3
+
+
+# A callback function to display the distance
+async def the_callback(data):
+    """
+    The callback function to display the change in distance
+    :param data: [report_type = PrivateConstants.SONAR_DISTANCE, trigger pin number, distance, timestamp]
+    """
+    date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(data[3]))
+    print(f'Sonar Report: Trigger Pin: {data[1]} Distance: {data[2]} Time: {date}')
+
+
+async def sonar(my_board, trigger_pin, echo_pin, callback):
+    """
+    Set the pin mode for a sonar device. Results will appear via the
+    callback.
+
+    :param my_board: a telemetrix_aio instance
+    :param trigger_pin: Arduino pin number
+    :param echo_pin: Arduino pin number
+    :param callback: The callback function
+    """
+
+    # set the pin mode for the trigger and echo pins
+    await my_board.set_pin_mode_sonar(trigger_pin, echo_pin, callback)
+    # wait forever
+    while True:
+        try:
+            await asyncio.sleep(5)
+            await my_board.sonar_disable()
+            await asyncio.sleep(5)
+            await my_board.sonar_enable()
+
+        except KeyboardInterrupt:
+            await my_board.shutdown()
+            sys.exit(0)
+
+
+# get the event loop
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+
+# instantiate telemetrix_aio
+board = telemetrix_aio.TelemetrixAIO()
+
+try:
+    # start the main function
+    loop.run_until_complete(sonar(board, TRIGGER_PIN, ECHO_PIN, the_callback))
+except KeyboardInterrupt:
+    loop.run_until_complete(board.shutdown())
+    sys.exit(0)

--- a/examples/wifi/sonar_disable.py
+++ b/examples/wifi/sonar_disable.py
@@ -1,0 +1,84 @@
+"""
+ Copyright (c) 2020 Alan Yorinks All rights reserved.
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ Version 3 as published by the Free Software Foundation; either
+ or (at your option) any later version.
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+
+ You should have received a copy of the GNU AFFERO GENERAL PUBLIC LICENSE
+ along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+"""
+
+import asyncio
+import sys
+import time
+from telemetrix_aio import telemetrix_aio
+
+"""
+This program continuously monitors an HC-SR04 Ultrasonic Sensor
+It reports changes to the distance sensed.
+"""
+TRIGGER_PIN = 4
+ECHO_PIN = 5
+
+# indices into callback data
+REPORT_TYPE = 0
+TRIG_PIN = 1
+DISTANCE = 2
+TIME = 3
+
+
+# A callback function to display the distance
+async def the_callback(data):
+    """
+    The callback function to display the change in distance
+    :param data: [report_type = PrivateConstants.SONAR_DISTANCE, trigger pin number, distance, timestamp]
+    """
+    date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(data[3]))
+    print(f'Sonar Report: Trigger Pin: {data[1]} Distance: {data[2]} Time: {date}')
+
+
+async def sonar(my_board, trigger_pin, echo_pin, callback):
+    """
+    Set the pin mode for a sonar device. Results will appear via the
+    callback.
+
+    :param my_board: telemetrix-aio instance
+    :param trigger_pin: Arduino pin number
+    :param echo_pin: Arduino pin number
+    :param callback: The callback function
+    """
+
+    # set the pin mode for the trigger and echo pins
+    await my_board.set_pin_mode_sonar(trigger_pin, echo_pin, callback)
+    # wait forever
+    while True:
+        try:
+            await asyncio.sleep(5)
+            await my_board.sonar_disable()
+            await asyncio.sleep(5)
+            await my_board.sonar_enable()
+
+        except KeyboardInterrupt:
+            await my_board.shutdown()
+            sys.exit(0)
+
+# get the event loop
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+
+# instantiate telemetrix_aio
+board = telemetrix_aio.TelemetrixAIO(ip_address='192.168.2.220')
+
+try:
+    # start the main function
+    loop.run_until_complete(sonar(board, TRIGGER_PIN, ECHO_PIN, the_callback))
+except KeyboardInterrupt:
+    loop.run_until_complete(board.shutdown())
+    sys.exit(0)

--- a/html/telemetrix_aio/index.html
+++ b/html/telemetrix_aio/index.html
@@ -1083,6 +1083,20 @@ class TelemetrixAIO:
                 await self.shutdown()
             raise RuntimeError(f&#39;The Stepper feature is disabled in the server.&#39;)
 
+    async def sonar_disable(self):
+        &#34;&#34;&#34;
+        Disable sonar scanning for all sonar sensors
+        &#34;&#34;&#34;
+        command = [PrivateConstants.SONAR_DISABLE]
+        await self._send_command(command)
+
+    async def sonar_enable(self):
+        &#34;&#34;&#34;
+        Enable sonar scanning for all sonar sensors
+        &#34;&#34;&#34;
+        command = [PrivateConstants.SONAR_ENABLE]
+        await self._send_command(command)
+
     async def spi_cs_control(self, chip_select_pin, select):
         &#34;&#34;&#34;
         Control an SPI chip select line
@@ -3572,6 +3586,20 @@ error occurs</p></div>
             if self.shutdown_on_exception:
                 await self.shutdown()
             raise RuntimeError(f&#39;The Stepper feature is disabled in the server.&#39;)
+
+    async def sonar_disable(self):
+        &#34;&#34;&#34;
+        Disable sonar scanning for all sonar sensors
+        &#34;&#34;&#34;
+        command = [PrivateConstants.SONAR_DISABLE]
+        await self._send_command(command)
+
+    async def sonar_enable(self):
+        &#34;&#34;&#34;
+        Enable sonar scanning for all sonar sensors
+        &#34;&#34;&#34;
+        command = [PrivateConstants.SONAR_ENABLE]
+        await self._send_command(command)
 
     async def spi_cs_control(self, chip_select_pin, select):
         &#34;&#34;&#34;
@@ -6368,6 +6396,40 @@ If any exceptions are thrown, they are ignored.</p></div>
         pass</code></pre>
 </details>
 </dd>
+<dt id="telemetrix_aio.telemetrix_aio.TelemetrixAIO.sonar_disable"><code class="name flex">
+<span>async def <span class="ident">sonar_disable</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Disable sonar scanning for all sonar sensors</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def sonar_disable(self):
+    &#34;&#34;&#34;
+    Disable sonar scanning for all sonar sensors
+    &#34;&#34;&#34;
+    command = [PrivateConstants.SONAR_DISABLE]
+    await self._send_command(command)</code></pre>
+</details>
+</dd>
+<dt id="telemetrix_aio.telemetrix_aio.TelemetrixAIO.sonar_enable"><code class="name flex">
+<span>async def <span class="ident">sonar_enable</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Enable sonar scanning for all sonar sensors</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">async def sonar_enable(self):
+    &#34;&#34;&#34;
+    Enable sonar scanning for all sonar sensors
+    &#34;&#34;&#34;
+    command = [PrivateConstants.SONAR_ENABLE]
+    await self._send_command(command)</code></pre>
+</details>
+</dd>
 <dt id="telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_cs_control"><code class="name flex">
 <span>async def <span class="ident">spi_cs_control</span></span>(<span>self, chip_select_pin, select)</span>
 </code></dt>
@@ -7646,6 +7708,8 @@ acceleration parameters.</p>
 <li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.set_pin_mode_spi" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.set_pin_mode_spi">set_pin_mode_spi</a></code></li>
 <li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.set_pin_mode_stepper" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.set_pin_mode_stepper">set_pin_mode_stepper</a></code></li>
 <li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.shutdown" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.shutdown">shutdown</a></code></li>
+<li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.sonar_disable" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.sonar_disable">sonar_disable</a></code></li>
+<li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.sonar_enable" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.sonar_enable">sonar_enable</a></code></li>
 <li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_cs_control" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_cs_control">spi_cs_control</a></code></li>
 <li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_read_blocking" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_read_blocking">spi_read_blocking</a></code></li>
 <li><code><a title="telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_set_format" href="#telemetrix_aio.telemetrix_aio.TelemetrixAIO.spi_set_format">spi_set_format</a></code></li>

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=['telemetrix_aio'],
     install_requires=['pyserial'],
 
-    version='1.11',
+    version='1.12',
 
     description="Remotely Control And Monitor Arduino-Core devices",
     long_description=long_description,

--- a/telemetrix_aio/private_constants.py
+++ b/telemetrix_aio/private_constants.py
@@ -78,6 +78,8 @@ class PrivateConstants:
     STEPPER_GET_DISTANCE_TO_GO = 52
     STEPPER_GET_TARGET_POSITION = 53
     GET_FEATURES = 54
+    SONAR_DISABLE = 55
+    SONAR_ENABLE = 56
 
     # reports
     # debug data from Arduino
@@ -100,9 +102,10 @@ class PrivateConstants:
     STEPPER_RUN_COMPLETE_REPORT = 19
     FEATURES = 20
 
+
     DEBUG_PRINT = 99
 
-    TELEMETRIX_AIO_VERSION = "1.11"
+    TELEMETRIX_AIO_VERSION = "1.12"
 
     # reporting control
     REPORTING_DISABLE_ALL = 0

--- a/telemetrix_aio/telemetrix_aio.py
+++ b/telemetrix_aio/telemetrix_aio.py
@@ -1040,6 +1040,20 @@ class TelemetrixAIO:
                 await self.shutdown()
             raise RuntimeError(f'The Stepper feature is disabled in the server.')
 
+    async def sonar_disable(self):
+        """
+        Disable sonar scanning for all sonar sensors
+        """
+        command = [PrivateConstants.SONAR_DISABLE]
+        await self._send_command(command)
+
+    async def sonar_enable(self):
+        """
+        Enable sonar scanning for all sonar sensors
+        """
+        command = [PrivateConstants.SONAR_ENABLE]
+        await self._send_command(command)
+
     async def spi_cs_control(self, chip_select_pin, select):
         """
         Control an SPI chip select line


### PR DESCRIPTION
Provide the ability to stop polling of HC-SR04 sensors and then reenable.